### PR TITLE
[auth][middleware] add jwt auth middleware

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .python-version
+.vscode

--- a/falcon_utils/jwt_auth.py
+++ b/falcon_utils/jwt_auth.py
@@ -1,0 +1,55 @@
+import os
+import requests
+import datetime
+from authlib.jose import jwt, JoseError
+from functools import lru_cache, wraps
+
+# TODO - update it appropriately
+BASE_URL = os.environ.get("CORE_BASE_URL", "http://localhost:9000")
+JWK_ENDPOINT = os.environ.get("JWK_ENDPOINT", "api/jwt/jwk")
+
+
+def timed_lru_cache(seconds: int, maxsize: int = None):
+    def wrapper_cache(func):
+        func = lru_cache(maxsize=maxsize)(func)
+        func.lifetime = datetime.timedelta(seconds=seconds)
+        func.expiration = datetime.datetime.utcnow() + func.lifetime
+
+        @wraps(func)
+        def wrapped_func(*args, **kwargs):
+            if datetime.datetime.utcnow() >= func.expiration:
+                func.cache_clear()
+                func.expiration = datetime.datetime.utcnow() + func.lifetime
+            return func(*args, **kwargs)
+
+        return wrapped_func
+
+    return wrapper_cache
+
+
+@timed_lru_cache(3600)
+def fetch_jwk():
+    url = f"{BASE_URL}/{JWK_ENDPOINT}"
+    headers = {"X-Api-Version": "v1"}
+    response = requests.get(url, headers=headers)
+
+    if response.status_code != 200:
+        return None
+
+    return response.json()
+
+
+def verify_token(token: str):
+    try:
+        jwk = fetch_jwk()
+        if not jwk:
+            return False, None
+
+        decoded_token = jwt.decode(token, jwk)
+        expires_at = decoded_token.get("exp")
+        if not expires_at or expires_at < int(datetime.datetime.utcnow().timestamp()):
+            return False, None
+
+        return True, decoded_token
+    except JoseError as err:
+        return False, None

--- a/falcon_utils/middlewares/auth_middleware.py
+++ b/falcon_utils/middlewares/auth_middleware.py
@@ -2,39 +2,33 @@ import falcon
 from datetime import datetime
 from falcon_utils.errors import UnAuthorizedSession
 
+from falcon_utils.jwt_auth import verify_token
+
 
 class SimpleAuthMiddleware(object):
     def __init__(self, config: dict, oauth_client=None):
         self.__config = config
         self.__oauth_client = oauth_client
-        
-        if self.__config.get("exempted_paths") is None:
-            self.__config["exempted_paths"] = []
 
-        if self.__config.get("clients") is None:
-            self.__config["clients"] = {}
-
-        if self.__config.get("api_keys") is None:
-            self.__config["api_keys"] = []
-        
-        if self.__config.get("ip_whitelist") is None:
-            self.__config["ip_whitelist"] = []
+        self.__config["exempted_paths"] = self.__config.get("exempted_paths", [])
+        self.__config["clients"] = self.__config.get("clients", {})
+        self.__config["api_keys"] = self.__config.get("api_keys", [])
+        self.__config["ip_whitelist"] = self.__config.get("ip_whitelist", [])
 
     def process_request(self, req: "falcon.Request", resp: "falcon.Response") -> object:
         self.request_initate_time = datetime.utcnow()
-       
-        if req.method == 'OPTIONS':
+
+        if req.method == "OPTIONS":
             resp.status = falcon.HTTP_200
             return
-       
-       
+
         token = None
         if req.path in self.__config.get("exempted_paths"):
             return
 
         if req.access_route[0] in self.__config.get("ip_whitelist"):
             return
-        
+
         if req.headers.get("X-API-KEY") in self.__config.get("api_keys"):
             return
 
@@ -42,21 +36,36 @@ class SimpleAuthMiddleware(object):
             req.headers.get("CLIENT-ID"),
             req.headers.get("CLIENT-SECRET"),
         )
-        if (self.__config.get("clients") or {}).get(client_id) == client_secret and client_id is not None and client_secret is not None:
+        if (
+            (self.__config.get("clients") or {}).get(client_id) == client_secret
+            and client_id is not None
+            and client_secret is not None
+        ):
             return
-        
-        
+
+        jwt_auth = req.headers.get("JWT", None)
+        if jwt_auth: 
+            verified, token = verify_token(jwt_auth)
+            if not verified:
+                raise UnAuthorizedSession()
+
+            setattr(req, "auth_payload", token)    
+            return       
+
         auth = req.headers.get("AUTHORIZATION", None)
         if auth and len(auth) > 0:
             auth_token_string = auth[7:]
             error, token = self.__oauth_client.introspection(
-                None, None, auth_token_string, 'access_token')
+                None, None, auth_token_string, "access_token"
+            )
             if not error:
-                error, oauth_user = self.__oauth_client.get_user(auth_token=auth_token_string)
+                error, oauth_user = self.__oauth_client.get_user(
+                    auth_token=auth_token_string
+                )
                 if not error and oauth_user.get("username"):
-                    setattr(req, 'user', oauth_user)
+                    setattr(req, "user", oauth_user)
                     return
-                
+
         raise UnAuthorizedSession()
 
     def process_response(self, req, resp, resource, params):


### PR DESCRIPTION
- Added auth middleware to verify `JWT` (if added) to incoming requests.
- `JWT` verification will take place by pulling `JWK` from `core-webserver`.
- `JWK` would be cached for an hour.

[Dependencies]
`authlib` - [Docs](https://docs.authlib.org/en/latest/index.html)
