### PR TITLE
[enhancement][auth] ability to add templated routes in exempted_paths config

### DIFF
--- a/falcon_utils/auth.py
+++ b/falcon_utils/auth.py
@@ -4,7 +4,7 @@ import requests
 import datetime
 from jwcrypto.jwt import JWT
 from jwcrypto.common import JWException
-from jwcrypto.jwk import JWK
+from jwcrypto.jwk import JWKSet
 from functools import lru_cache, wraps
 
 
@@ -45,8 +45,8 @@ class JWTVerifyService:
             if not jwk_dict:
                 return False, None
 
-            jwk = JWK(**jwk_dict)
-            decoded_token = JWT(key=jwk, jwt=token)
+            jwk_set = JWKSet.from_json(json.dumps(jwk_dict))
+            decoded_token = JWT(key=jwk_set, jwt=token)
             
             claims = json.loads(decoded_token.claims)
             expires_at = claims.get("exp")

--- a/falcon_utils/auth.py
+++ b/falcon_utils/auth.py
@@ -22,7 +22,9 @@ def timed_lru_cache(seconds: int, maxsize: int = 128):
 
             result = func(*args, **kwargs)
             return result
+
         return wrapped_func
+
     return wrapper_cache
 
 
@@ -41,13 +43,13 @@ class JWTVerifyService:
 
     def verify(self, token: str):
         try:
-            jwk_dict = self.fetch_jwk()
-            if not jwk_dict:
+            jwk_api_response = self.fetch_jwk()
+            if not jwk_api_response:
                 return False, None
 
-            jwk_set = JWKSet.from_json(json.dumps(jwk_dict))
+            jwk_set = JWKSet.from_json(json.dumps(jwk_api_response))
             decoded_token = JWT(key=jwk_set, jwt=token)
-            
+
             claims = json.loads(decoded_token.claims)
             expires_at = claims.get("exp")
             if not expires_at or expires_at < int(
@@ -70,6 +72,6 @@ class AuthorizationScheme(Enum):
 
 
 class AccessLevel(Enum):
-    SELF = 'self'
-    DEPENDANT = 'dependant'
-    SELF_AND_DEPENDANT = 'self_and_dependant'
+    SELF = "self"
+    DEPENDANT = "dependant"
+    SELF_AND_DEPENDANT = "self_and_dependant"

--- a/falcon_utils/middlewares/auth_middleware.py
+++ b/falcon_utils/middlewares/auth_middleware.py
@@ -1,3 +1,4 @@
+from typing import List, Optional
 import falcon
 from datetime import datetime
 from falcon_utils.errors import UnAuthorizedSession
@@ -84,11 +85,15 @@ class SimpleAuthMiddleware(object):
         In case no authorization scheme is specified, endpoint is assumed to be
         publicly available.
         """
-        authorization_schemes = getattr(resource, "authorization_schemes", [])
+        authorization_schemes: "List[AuthorizationScheme]" = getattr(
+            resource, "authorization_schemes", []
+        )
         if len(authorization_schemes) == 0:
             return
 
-        request_authorization_scheme = req.context.get("authorization_scheme", None)
+        request_authorization_scheme: "Optional[AuthorizationScheme]" = req.context.get(
+            "authorization_scheme", None
+        )
         if (
             request_authorization_scheme is None
             or request_authorization_scheme not in authorization_schemes


### PR DESCRIPTION
Moved the handling of `exempted_paths` in `SimpleAuthMiddleware` from `process_request` method to `process_response`. This is to allow handling of templated routes in `exempted_paths` list. Also removed the check which allowed all routes to be publicly available in case no `authorization_scheme` list was provided. 