### PR TITLE
[feat][mixin] add api versioning mixin

### DIFF
--- a/falcon_utils/mixins/__init__.py
+++ b/falcon_utils/mixins/__init__.py
@@ -1,0 +1,1 @@
+from .api_version import ApiVersioningScheme

--- a/falcon_utils/mixins/api_version.py
+++ b/falcon_utils/mixins/api_version.py
@@ -11,9 +11,9 @@ class ApiVersioningScheme(object):
             self.get(req, resp, *args, **kwargs)
             return
 
-        route_handler: Callable[
-            [falcon.Request, falcon.Response, Tuple, Dict], None
-        ] = getattr(self, f"on_get_{api_version}", None)
+        route_handler: "Callable[[falcon.Request, falcon.Response, Tuple, Dict], None]" = getattr(
+            self, f"on_get_{api_version}", None
+        )
         if not route_handler:
             raise InvalidApiVersionScheme()
 
@@ -25,9 +25,9 @@ class ApiVersioningScheme(object):
             self.post(req, resp, *args, **kwargs)
             return
 
-        route_handler: Callable[
-            [falcon.Request, falcon.Response, Tuple, Dict], None
-        ] = getattr(self, f"on_post_{api_version}", None)
+        route_handler: "Callable[[falcon.Request, falcon.Response, Tuple, Dict], None]" = getattr(
+            self, f"on_post_{api_version}", None
+        )
         if not route_handler:
             raise InvalidApiVersionScheme()
 

--- a/falcon_utils/mixins/api_version.py
+++ b/falcon_utils/mixins/api_version.py
@@ -1,0 +1,34 @@
+from typing import Callable, Dict, Optional, Tuple
+import falcon
+
+from falcon_utils.errors import InvalidApiVersionScheme
+
+
+class ApiVersioningScheme(object):
+    def on_get(self, req: "falcon.Request", resp: "falcon.Request", *args, **kwargs):
+        api_version: "Optional[str]" = req.headers.get("X-API-VERSION")
+        if not api_version:
+            self.get(req, resp, *args, **kwargs)
+            return
+
+        route_handler: Callable[
+            [falcon.Request, falcon.Response, Tuple, Dict], None
+        ] = getattr(self, f"on_get_{api_version}", None)
+        if not route_handler:
+            raise InvalidApiVersionScheme()
+
+        route_handler(req, resp, *args, **kwargs)
+
+    def on_post(self, req: "falcon.Request", resp: "falcon.Request", *args, **kwargs):
+        api_version: "Optional[str]" = req.headers.get("X-API-VERSION")
+        if not api_version:
+            self.post(req, resp, *args, **kwargs)
+            return
+
+        route_handler: Callable[
+            [falcon.Request, falcon.Response, Tuple, Dict], None
+        ] = getattr(self, f"on_post_{api_version}", None)
+        if not route_handler:
+            raise InvalidApiVersionScheme()
+
+        route_handler(req, resp, *args, **kwargs)

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,8 @@ setup(
         'falcon_utils.routes',
         'falcon_utils.hooks',
         'falcon_utils.hooks.mongo',
-        'falcon_utils.response'
+        'falcon_utils.response',
+        'falcon_utils.mixins'
     ],
     version='0.1.1',
     author="Develper Junio",


### PR DESCRIPTION
Added `ApiVersioningScheme` mixin, that will allow other resources to inherit using this mixin and enable API versioning based on `X-API-VERSION` header. Route handlers are resolved based on following naming convention `on_get_{version}` etc. Currently only `on_get_{version}` and `on_post_{version}` are available.