### PR TITLE
[fix][auth] handle ValueError in JWTVerifyService

### DIFF
--- a/falcon_utils/auth.py
+++ b/falcon_utils/auth.py
@@ -58,7 +58,7 @@ class JWTVerifyService:
                 return False, None
 
             return True, claims
-        except JWException as err:
+        except (JWException, ValueError) as err:
             return False, None
 
 


### PR DESCRIPTION
In case of improper JWT, `ValueError` was not being handled. Added `ValueError` as part of handled exceptions