### PR TITLE
[fix][hooks] `AuthorizePayload` should only run for JWT

### DIFF
--- a/falcon_utils/hooks/authorize_payload.py
+++ b/falcon_utils/hooks/authorize_payload.py
@@ -1,7 +1,7 @@
 import falcon
 from typing import Any, Callable, Dict, Tuple
 
-from falcon_utils.auth import AccessLevel
+from falcon_utils.auth import AccessLevel, AuthorizationScheme
 from falcon_utils.errors import UnAuthorizedSession
 
 
@@ -19,6 +19,10 @@ class AuthorizePayload:
     def __call__(
         self, req: "falcon.Request", resp: "falcon.Response", resource, params: "Dict"
     ) -> None:
+        authorization_scheme = req.context.get("authorization_scheme")
+        if authorization_scheme != AuthorizationScheme.JWT:
+            return
+        
         authorization_payload = req.context.get("authorization_payload")
         if authorization_payload == None:
             raise UnAuthorizedSession()


### PR DESCRIPTION
`AuthorizePayload` hook only needs to run for JWT based authorization, for other authorization based schemes we don't have a payload, so the check should be bypassed.